### PR TITLE
Add Odin bouncing ball example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+odin-bin/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Odin Ball Bounce Example
+
+This repository contains a small example game written in [Odin](https://odin-lang.org). It displays a ball bouncing around the window using `vendor:raylib`.
+
+## Building on Linux
+
+Make sure you have the Odin compiler available (see `deps.sh` if you need to download the nightly build). Run:
+
+```bash
+odin run ball_bounce
+```
+
+This compiles and launches the program for the host platform.
+
+## Building and running on macOS (Metal)
+
+On macOS you can build and run the project directly. Odin will automatically use Metal via the system frameworks when available.
+
+```bash
+odin run ball_bounce -target:macos_arm64
+```
+
+Adjust the target architecture (`macos_arm64` or `macos_amd64`) depending on your machine. The resulting application will render using Metal.
+
+## Building for Web (WASM + WebGL)
+
+To build the same project for the web you can target `js_wasm32` and produce a `.wasm` file along with the runtime JavaScript helper:
+
+```bash
+odin build ball_bounce -target:js_wasm32 -out:ball_bounce.wasm -no-entry
+cp $(odin root)/core/sys/wasm/js/odin.js .
+```
+
+Then create a minimal HTML file that loads `odin.js` and your `ball_bounce.wasm` and open it with a web browser that supports WebGL.
+

--- a/ball_bounce/main.odin
+++ b/ball_bounce/main.odin
@@ -1,0 +1,35 @@
+package main
+
+import rl "vendor:raylib"
+
+SCREEN_WIDTH  :: 800
+SCREEN_HEIGHT :: 450
+
+main :: proc() {
+    rl.InitWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "Bouncing Ball")
+    defer rl.CloseWindow()
+
+    ball_pos   := rl.Vector2{f32(SCREEN_WIDTH) / 2, f32(SCREEN_HEIGHT) / 2}
+    ball_speed := rl.Vector2{200, 150} // pixels per second
+    ball_radius: f32 = 20
+
+    rl.SetTargetFPS(60)
+
+    for !rl.WindowShouldClose() {
+        dt := rl.GetFrameTime()
+        ball_pos.x += ball_speed.x * dt
+        ball_pos.y += ball_speed.y * dt
+
+        if ball_pos.x > f32(SCREEN_WIDTH) - ball_radius || ball_pos.x < ball_radius {
+            ball_speed.x = -ball_speed.x
+        }
+        if ball_pos.y > f32(SCREEN_HEIGHT) - ball_radius || ball_pos.y < ball_radius {
+            ball_speed.y = -ball_speed.y
+        }
+
+        rl.BeginDrawing()
+            rl.ClearBackground(rl.RAYWHITE)
+            rl.DrawCircleV(ball_pos, ball_radius, rl.RED)
+        rl.EndDrawing()
+    }
+}


### PR DESCRIPTION
## Summary
- add bouncing ball example using vendor:raylib
- add README instructions for Linux, macOS (Metal), and Web builds
- ignore odin-bin

## Testing
- `odin run ball_bounce` *(fails: X11 DISPLAY missing)*

------
https://chatgpt.com/codex/tasks/task_e_685b426f9cb08326944196e832a5d8e7