### PR TITLE
Add wasm build helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Adjust the target architecture (`macos_arm64` or `macos_amd64`) depending on you
 To build the same project for the web you can target `js_wasm32` and produce a `.wasm` file along with the runtime JavaScript helper:
 
 ```bash
-odin build ball_bounce -target:js_wasm32 -out:ball_bounce.wasm -no-entry-point
+odin build ball_bounce -target:js_wasm32 -out:ball_bounce.wasm
 cp $(odin root)/core/sys/wasm/js/odin.js .
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Adjust the target architecture (`macos_arm64` or `macos_amd64`) depending on you
 
 ## Building for Web (WASM + WebGL)
 
+Even if you installed Odin using Homebrew you must run `./deps.sh` once to fetch
+the vendor libraries used for WebAssembly builds.
+
 To build the same project for the web you can target `js_wasm32` and produce a `.wasm` file along with the runtime JavaScript helper:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -36,7 +36,18 @@ mkdir -p wasm
 cp $(odin root)/vendor/raylib/wasm/libraylib.a wasm/
 ```
 
-Then create a minimal HTML file that loads `odin.js` and your `ball_bounce.wasm` and open it with a web browser that supports WebGL. Modern browsers do not allow loading these files directly from the filesystem, so serve them through a local HTTP server, e.g.
+Then create a minimal HTML file that loads `odin.js`, fetches the `wasm/libraylib.a` support library, and passes it to `odin.runWasm` before opening the page in a WebGL-enabled browser. A simple snippet looks like:
+
+```html
+<script>
+(async () => {
+    const lib = await fetch('wasm/libraylib.a').then(r => r.arrayBuffer()).then(b => WebAssembly.instantiate(b, {}));
+    await odin.runWasm('ball_bounce.wasm', undefined, { 'wasm/libraylib.a': lib.instance.exports });
+})();
+</script>
+```
+
+Modern browsers do not allow loading these files directly from the filesystem, so serve them through a local HTTP server, e.g.
 
 ```bash
 python3 -m http.server

--- a/README.md
+++ b/README.md
@@ -27,9 +27,15 @@ Adjust the target architecture (`macos_arm64` or `macos_amd64`) depending on you
 To build the same project for the web you can target `js_wasm32` and produce a `.wasm` file along with the runtime JavaScript helper:
 
 ```bash
-odin build ball_bounce -target:js_wasm32 -out:ball_bounce.wasm -no-entry
+odin build ball_bounce -target:js_wasm32 -out:ball_bounce.wasm -no-entry-point
 cp $(odin root)/core/sys/wasm/js/odin.js .
 ```
 
 Then create a minimal HTML file that loads `odin.js` and your `ball_bounce.wasm` and open it with a web browser that supports WebGL.
+
+Alternatively you can run the provided helper script which performs all of the above steps and writes the HTML file automatically:
+
+```bash
+./wasm.sh
+```
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ To build the same project for the web you can target `js_wasm32` and produce a `
 ```bash
 odin build ball_bounce -target:js_wasm32 -out:ball_bounce.wasm
 cp $(odin root)/core/sys/wasm/js/odin.js .
+mkdir -p wasm
+cp $(odin root)/vendor/raylib/wasm/libraylib.a wasm/
 ```
 
 Then create a minimal HTML file that loads `odin.js` and your `ball_bounce.wasm` and open it with a web browser that supports WebGL.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ mkdir -p wasm
 cp $(odin root)/vendor/raylib/wasm/libraylib.a wasm/
 ```
 
-Then create a minimal HTML file that loads `odin.js` and your `ball_bounce.wasm` and open it with a web browser that supports WebGL.
+Then create a minimal HTML file that loads `odin.js` and your `ball_bounce.wasm` and open it with a web browser that supports WebGL. Modern browsers do not allow loading these files directly from the filesystem, so serve them through a local HTTP server, e.g.
+
+```bash
+python3 -m http.server
+```
+and visit `http://localhost:8000/ball_bounce.html`.
 
 Alternatively you can run the provided helper script which performs all of the above steps and writes the HTML file automatically:
 

--- a/wasm.sh
+++ b/wasm.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+
+# Determine Odin command
+ODIN=${ODIN:-odin}
+if ! command -v "$ODIN" >/dev/null 2>&1; then
+    ODIN="./odin-bin/odin-linux-amd64-nightly+2025-06-02/odin"
+fi
+
+# Build the example to WebAssembly
+"$ODIN" build ball_bounce -target:js_wasm32 -out:ball_bounce.wasm -no-entry-point
+
+# Copy the Odin runtime JavaScript helper next to the wasm file
+ODIN_ROOT=$("$ODIN" root)
+cp "$ODIN_ROOT/core/sys/wasm/js/odin.js" .
+
+# Generate a minimal HTML file to load the wasm module
+cat >ball_bounce.html <<'HTML'
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="odin.js"></script>
+</head>
+<body>
+  <script>
+    odin.runWasm('ball_bounce.wasm');
+  </script>
+</body>
+</html>
+HTML
+
+printf '\nGenerated ball_bounce.html. Open it in a WebGL-enabled browser.\n'

--- a/wasm.sh
+++ b/wasm.sh
@@ -10,8 +10,14 @@ fi
 # Build the example to WebAssembly
 "$ODIN" build ball_bounce -target:js_wasm32 -out:ball_bounce.wasm
 
-# Copy the Odin runtime JavaScript helper next to the wasm file
+# Discover Odin root path for runtime resources
 ODIN_ROOT=$("$ODIN" root)
+
+# Copy the vendor raylib WASM library expected by odin.js
+mkdir -p wasm
+cp "$ODIN_ROOT/vendor/raylib/wasm/libraylib.a" wasm/
+
+# Copy the Odin runtime JavaScript helper next to the wasm file
 cp "$ODIN_ROOT/core/sys/wasm/js/odin.js" .
 
 # Generate a minimal HTML file to load the wasm module

--- a/wasm.sh
+++ b/wasm.sh
@@ -35,7 +35,11 @@ cat >ball_bounce.html <<'HTML'
 </head>
 <body>
   <script>
-    odin.runWasm('ball_bounce.wasm');
+    (async () => {
+      const libResp = await fetch('wasm/libraylib.a');
+      const raylib = await WebAssembly.instantiate(await libResp.arrayBuffer(), {});
+      await odin.runWasm('ball_bounce.wasm', undefined, { 'wasm/libraylib.a': raylib.instance.exports });
+    })();
   </script>
 </body>
 </html>

--- a/wasm.sh
+++ b/wasm.sh
@@ -14,8 +14,13 @@ fi
 ODIN_ROOT=$("$ODIN" root)
 
 # Copy the vendor raylib WASM library expected by odin.js
+# Prefer the one fetched by deps.sh in odin-bin so Homebrew installs work
 mkdir -p wasm
-cp "$ODIN_ROOT/vendor/raylib/wasm/libraylib.a" wasm/
+RAYLIB_WASM=$(find odin-bin -path '*/vendor/raylib/wasm/libraylib.a' 2>/dev/null | head -n 1)
+if [ -z "$RAYLIB_WASM" ]; then
+    RAYLIB_WASM="$ODIN_ROOT/vendor/raylib/wasm/libraylib.a"
+fi
+cp "$RAYLIB_WASM" wasm/
 
 # Copy the Odin runtime JavaScript helper next to the wasm file
 cp "$ODIN_ROOT/core/sys/wasm/js/odin.js" .

--- a/wasm.sh
+++ b/wasm.sh
@@ -8,7 +8,7 @@ if ! command -v "$ODIN" >/dev/null 2>&1; then
 fi
 
 # Build the example to WebAssembly
-"$ODIN" build ball_bounce -target:js_wasm32 -out:ball_bounce.wasm -no-entry-point
+"$ODIN" build ball_bounce -target:js_wasm32 -out:ball_bounce.wasm
 
 # Copy the Odin runtime JavaScript helper next to the wasm file
 ODIN_ROOT=$("$ODIN" root)

--- a/wasm.sh
+++ b/wasm.sh
@@ -42,3 +42,4 @@ cat >ball_bounce.html <<'HTML'
 HTML
 
 printf '\nGenerated ball_bounce.html. Open it in a WebGL-enabled browser.\n'
+printf 'Run `python3 -m http.server` and navigate to http://localhost:8000/ball_bounce.html\n'


### PR DESCRIPTION
## Summary
- add `wasm.sh` script to automate WebAssembly builds
- update README with instructions for the new helper

## Testing
- `bash -n wasm.sh`
- `./wasm.sh > /tmp/wasm.log && tail -n 20 /tmp/wasm.log`

------
https://chatgpt.com/codex/tasks/task_e_685b45bb6b2c8326bb273d7516a25bc7